### PR TITLE
비밀번호 내용 on/off 할 수 있는 password-input 

### DIFF
--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+
+export interface PasswordInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  suffix?: React.ReactNode;
+}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ suffix, className, type, ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+
+    const togglePasswordVisibility = () => {
+      setShowPassword((prevShowPassword) => !prevShowPassword);
+    };
+
+    return (
+      <div className="flex gap-2 items-center">
+        <input
+          type={showPassword ? "text" : "password"}
+          className={cn(
+            "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+            className,
+          )}
+          ref={ref}
+          {...props}
+        />
+        <button
+          type="button"
+          className="absolute right-3 opacity-50"
+          onClick={togglePasswordVisibility}
+          aria-label="Toggle password visibility"
+        >
+          {showPassword ? <EyeIcon /> : <EyeOffIcon />}
+        </button>
+      </div>
+    );
+  },
+);
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };


### PR DESCRIPTION
### 변경사항
비밀번호 내용 on/off 할 수 있는 password-input 입니다.
도연님 파트에서 적용해서 쓰시면 될 것 같아요!
import 할 때 도연님이 만들어놓으신 passwordInput 들어갈 수도 있으니 경로 잘 봐주세요.

### 사용 예시
```
import { FormControl, FormItem, FormLabel } from "@/components/ui/form";
import { PasswordInput } from "@/components/ui/password-input";

export function CurrentPasswordInput() {
  return (
    <FormItem className="relative">
      <FormLabel className="text-lg">현재 비밀번호</FormLabel>
      <FormControl>
        <PasswordInput
          placeholder="현재 비밀번호 입력"
          className=" text-md h-12 font-normal placeholder:opacity-50"
        />
      </FormControl>
    </FormItem>
  );
}
```

도연님 참고) 로그인/회원가입에서 input 쓰실 때는 위 코드처럼 FormField 제거해주세용 